### PR TITLE
Live Tracing - Simple Tracer

### DIFF
--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -2024,9 +2024,15 @@ func (bc *BlockChain) processBlock(block *types.Block, statedb *state.StateDB, s
 			Safe:      bc.CurrentSafeBlock(),
 		})
 	}
-	if bc.logger != nil && bc.logger.OnBlockEnd != nil {
+	if bc.logger != nil && bc.logger.OnBlockEnd != nil && bc.logger.OnBlockEndV2 != nil {
 		defer func() {
 			bc.logger.OnBlockEnd(blockEndErr)
+			bc.logger.OnBlockEndV2(blockEndErr, tracing.BlockEvent{
+				Block:     block,
+				Finalized: bc.CurrentFinalBlock(),
+				Safe:      bc.CurrentSafeBlock(),
+				TD:        bc.GetTd(block.ParentHash(), block.NumberU64()-1),
+			})
 		}()
 	}
 

--- a/core/tracing/hooks.go
+++ b/core/tracing/hooks.go
@@ -41,6 +41,7 @@ type StateDB interface {
 	GetBalance(common.Address) *uint256.Int
 	GetNonce(common.Address) uint64
 	GetCode(common.Address) []byte
+	GetCodeHash(addr common.Address) common.Hash
 	GetState(common.Address, common.Hash) common.Hash
 	Exist(common.Address) bool
 	GetRefund() uint64
@@ -128,6 +129,8 @@ type (
 	// BlockEndHook is called after executing a block.
 	BlockEndHook = func(err error)
 
+	BlockEndHookV2 = func(err error, event BlockEvent)
+
 	// SkippedBlockHook indicates a block was skipped during processing
 	// due to it being known previously. This can happen e.g. when recovering
 	// from a crash.
@@ -192,6 +195,7 @@ type Hooks struct {
 	OnClose           CloseHook
 	OnBlockStart      BlockStartHook
 	OnBlockEnd        BlockEndHook
+	OnBlockEndV2      BlockEndHookV2
 	OnSkippedBlock    SkippedBlockHook
 	OnGenesisBlock    GenesisBlockHook
 	OnSystemCallStart OnSystemCallStartHook

--- a/eth/tracers/live/noop.go
+++ b/eth/tracers/live/noop.go
@@ -34,6 +34,7 @@ func newNoopTracer(_ json.RawMessage) (*tracing.Hooks, error) {
 		OnBlockchainInit: t.OnBlockchainInit,
 		OnBlockStart:     t.OnBlockStart,
 		OnBlockEnd:       t.OnBlockEnd,
+		OnBlockEndV2:     t.OnBlockEndV2,
 		OnSkippedBlock:   t.OnSkippedBlock,
 		OnGenesisBlock:   t.OnGenesisBlock,
 		OnBalanceChange:  t.OnBalanceChange,
@@ -66,6 +67,9 @@ func (t *noop) OnBlockStart(ev tracing.BlockEvent) {
 }
 
 func (t *noop) OnBlockEnd(err error) {
+}
+
+func (t *noop) OnBlockEndV2(err error, ev tracing.BlockEvent) {
 }
 
 func (t *noop) OnSkippedBlock(ev tracing.BlockEvent) {}

--- a/eth/tracers/live/tenderly_simple_hooks.go
+++ b/eth/tracers/live/tenderly_simple_hooks.go
@@ -27,6 +27,7 @@ func NewTenderlySimpleTracerHooks(jsonConfig json.RawMessage) (*gethtracing.Hook
 		OnClose:           tracer.OnClose,
 		OnBlockStart:      tracer.OnBlockStart,
 		OnBlockEnd:        tracer.OnBlockEnd,
+		OnBlockEndV2:      tracer.OnBlockEndV2,
 		OnSystemCallStart: tracer.OnSystemCallStart,
 		OnSystemCallEnd:   tracer.OnSystemCallEnd,
 		//OnSystemCallStartV2: tracer.OnSystemCallStartV2,

--- a/eth/tracers/live/tenderly_simple_hooks.go
+++ b/eth/tracers/live/tenderly_simple_hooks.go
@@ -1,0 +1,46 @@
+package live
+
+import (
+	"encoding/json"
+	gethtracing "github.com/ethereum/go-ethereum/core/tracing"
+	gethtracers "github.com/ethereum/go-ethereum/eth/tracers"
+)
+
+// init registers the tenderly tracer hooks with the gethtracers.LiveDirectory
+func init() {
+	gethtracers.LiveDirectory.Register("tenderly_simple_tracer_hooks", NewTenderlySimpleTracerHooks)
+}
+
+// NewTenderlySimpleTracerHooks creates a new set of tracer hooks for the tenderly tracer.
+func NewTenderlySimpleTracerHooks(jsonConfig json.RawMessage) (*gethtracing.Hooks, error) {
+	// tracer
+	tracer := NewTenderlySimpleTracer()
+
+	// hook the tracer
+	return &gethtracing.Hooks{
+		OnTxStart: tracer.OnTxStart,
+		OnTxEnd:   tracer.OnTxEnd,
+		OnEnter:   tracer.OnEnter,
+		OnExit:    tracer.OnExit,
+		OnOpcode:  tracer.OnOpcode,
+
+		OnClose:           tracer.OnClose,
+		OnBlockStart:      tracer.OnBlockStart,
+		OnBlockEnd:        tracer.OnBlockEnd,
+		OnSystemCallStart: tracer.OnSystemCallStart,
+		OnSystemCallEnd:   tracer.OnSystemCallEnd,
+		//OnSystemCallStartV2: tracer.OnSystemCallStartV2,
+
+		OnBalanceChange: tracer.OnBalanceChange,
+		OnNonceChange:   tracer.OnNonceChange,
+		OnCodeChange:    tracer.OnCodeChange,
+		OnStorageChange: tracer.OnStorageChange,
+
+		//OnBalanceRead:  inner.OnBalanceRead,
+		//OnNonceRead:    inner.OnNonceRead,
+		//OnCodeRead:     inner.OnCodeRead,
+		//OnCodeSizeRead: inner.OnCodeSizeRead,
+		//OnCodeHashRead: inner.OnCodeHashRead,
+		//OnStorageRead:  inner.OnStorageRead,
+	}, nil
+}

--- a/eth/tracers/live/tenderly_simple_tracer.go
+++ b/eth/tracers/live/tenderly_simple_tracer.go
@@ -11,6 +11,7 @@ import (
 type TenderlySimpleTracer interface {
 	OnBlockStart(event gethtracing.BlockEvent)
 	OnBlockEnd(err error)
+	OnBlockEndV2(err error, event gethtracing.BlockEvent)
 	OnClose()
 	OnSystemCallStart()
 	OnSystemCallStartV2(ctx *gethtracing.VMContext)
@@ -57,6 +58,10 @@ func (t *simpleTracer) OnBlockStart(event gethtracing.BlockEvent) {
 
 func (t *simpleTracer) OnBlockEnd(err error) {
 	//log.Info("tenderly::OnBlockEnd", "err", err)
+}
+
+func (t *simpleTracer) OnBlockEndV2(err error, event gethtracing.BlockEvent) {
+	//log.Info("tenderly::OnBlockEndV2", "err", err, "event", event)
 }
 
 func (t *simpleTracer) OnClose() {

--- a/eth/tracers/live/tenderly_simple_tracer.go
+++ b/eth/tracers/live/tenderly_simple_tracer.go
@@ -1,0 +1,137 @@
+package live
+
+import (
+	gethcommon "github.com/ethereum/go-ethereum/common"
+	gethtracing "github.com/ethereum/go-ethereum/core/tracing"
+	gethtypes "github.com/ethereum/go-ethereum/core/types"
+	"math/big"
+)
+
+// TenderlySimpleTracer is an interface that is used to trace the execution of a block.
+type TenderlySimpleTracer interface {
+	OnBlockStart(event gethtracing.BlockEvent)
+	OnBlockEnd(err error)
+	OnClose()
+	OnSystemCallStart()
+	OnSystemCallStartV2(ctx *gethtracing.VMContext)
+	OnSystemCallEnd()
+	OnTxStart(ctx *gethtracing.VMContext, tx *gethtypes.Transaction, from gethcommon.Address)
+	OnTxEnd(receipt *gethtypes.Receipt, err error)
+	OnEnter(_ int, typ byte, from gethcommon.Address, to gethcommon.Address, input []byte, gas uint64, value *big.Int)
+	OnExit(_ int, output []byte, used uint64, err error, reverted bool)
+	OnOpcode(pc uint64, typ byte, gas, cost uint64, scope gethtracing.OpContext, rData []byte, depth int, err error)
+	OnBalanceChange(addr gethcommon.Address, prev *big.Int, n *big.Int, reason gethtracing.BalanceChangeReason)
+	OnNonceChange(addr gethcommon.Address, prev, new uint64)
+	OnCodeChange(addr gethcommon.Address, prevCodeHash gethcommon.Hash, prevCode []byte, codeHash gethcommon.Hash, code []byte)
+	OnStorageChange(addr gethcommon.Address, slot gethcommon.Hash, prev, new gethcommon.Hash)
+	OnBalanceRead(addr gethcommon.Address, bal *big.Int)
+	OnNonceRead(addr gethcommon.Address, nonce uint64)
+	OnCodeRead(addr gethcommon.Address, code []byte)
+	OnCodeSizeRead(addr gethcommon.Address, size int)
+	OnCodeHashRead(addr gethcommon.Address, hash gethcommon.Hash)
+	OnStorageRead(addr gethcommon.Address, slot gethcommon.Hash, value gethcommon.Hash)
+}
+
+// Ensure that simpleTracer implements the TenderlySimpleTracer interface.
+var _ TenderlySimpleTracer = (*simpleTracer)(nil)
+
+// simpleTracer is a simple implementation of the TenderlySimpleTracer interface.
+// It just represents the tenderly tracing flow.
+// We hook to the gethtracing.Hooks to get the tracing events.
+// We build the block and transaction data from the tracing events.
+// OnBlockEnd, we send the block data to the tenderly pipeline for further processing.
+type simpleTracer struct {
+	block *gethtypes.Block
+	tx    *gethtypes.Transaction
+}
+
+// NewTenderlySimpleTracer creates a new instance of the simpleTracer.
+func NewTenderlySimpleTracer() TenderlySimpleTracer {
+	return &simpleTracer{}
+}
+
+func (t *simpleTracer) OnBlockStart(event gethtracing.BlockEvent) {
+	//log.Info("tenderly::OnBlockStart", "event", event)
+	t.block = event.Block
+}
+
+func (t *simpleTracer) OnBlockEnd(err error) {
+	//log.Info("tenderly::OnBlockEnd", "err", err)
+}
+
+func (t *simpleTracer) OnClose() {
+	//log.Info("tenderly::OnClose")
+}
+
+func (t *simpleTracer) OnSystemCallStart() {
+	//log.Info("tenderly::OnSystemCallStart")
+}
+
+func (t *simpleTracer) OnSystemCallStartV2(ctx *gethtracing.VMContext) {
+	//log.Info("tenderly::OnSystemCallStartV2", "ctx", ctx)
+}
+
+func (t *simpleTracer) OnSystemCallEnd() {
+	//log.Info("tenderly::OnSystemCallEnd")
+}
+
+func (t *simpleTracer) OnTxStart(ctx *gethtracing.VMContext, tx *gethtypes.Transaction, from gethcommon.Address) {
+	//log.Info("tenderly::OnTxStart", "ctx", ctx, "tx", tx, "from", from)
+	t.tx = tx
+}
+
+func (t *simpleTracer) OnTxEnd(receipt *gethtypes.Receipt, err error) {
+	//log.Info("tenderly::OnTxEnd", "receipt", receipt, "err", err)
+}
+
+func (t *simpleTracer) OnEnter(_ int, typ byte, from gethcommon.Address, to gethcommon.Address, input []byte, gas uint64, value *big.Int) {
+	//log.Info("tenderly::OnEnter", "typ", typ, "from", from, "to", to, "input", input, "gas", gas, "value", value)
+}
+
+func (t *simpleTracer) OnExit(_ int, output []byte, used uint64, err error, reverted bool) {
+	//log.Info("tenderly::OnExit", "output", output, "used", used, "err", err, "reverted", reverted)
+}
+
+func (t *simpleTracer) OnOpcode(pc uint64, typ byte, gas, cost uint64, scope gethtracing.OpContext, rData []byte, depth int, err error) {
+	//log.Info("tenderly::OnOpcode", "pc", pc, "typ", typ, "gas", gas, "cost", cost, "scope", scope, "rData", rData, "depth", depth, "err", err)
+}
+
+func (t *simpleTracer) OnBalanceChange(addr gethcommon.Address, prev *big.Int, n *big.Int, reason gethtracing.BalanceChangeReason) {
+	//log.Info("tenderly::OnBalanceChange", "addr", addr, "prev", prev, "n", n, "reason", reason)
+}
+
+func (t *simpleTracer) OnNonceChange(addr gethcommon.Address, prev, new uint64) {
+	//log.Info("tenderly::OnNonceChange", "addr", addr, "prev", prev, "new", new)
+}
+
+func (t *simpleTracer) OnCodeChange(addr gethcommon.Address, prevCodeHash gethcommon.Hash, prevCode []byte, codeHash gethcommon.Hash, code []byte) {
+	//log.Info("tenderly::OnCodeChange", "addr", addr, "prevCodeHash", prevCodeHash, "prevCode", prevCode, "codeHash", codeHash, "code", code)
+}
+
+func (t *simpleTracer) OnStorageChange(addr gethcommon.Address, slot gethcommon.Hash, prev, new gethcommon.Hash) {
+	//log.Info("tenderly::OnStorageChange", "addr", addr, "slot", slot, "prev", prev, "new", new)
+}
+
+func (t *simpleTracer) OnBalanceRead(addr gethcommon.Address, bal *big.Int) {
+	//log.Info("tenderly::OnBalanceRead", "addr", addr, "bal", bal)
+}
+
+func (t *simpleTracer) OnNonceRead(addr gethcommon.Address, nonce uint64) {
+	//log.Info("tenderly::OnNonceRead", "addr", addr, "nonce", nonce)
+}
+
+func (t *simpleTracer) OnCodeRead(addr gethcommon.Address, code []byte) {
+	//log.Info("tenderly::OnCodeRead", "addr", addr, "code", code)
+}
+
+func (t *simpleTracer) OnCodeSizeRead(addr gethcommon.Address, size int) {
+	//log.Info("tenderly::OnCodeSizeRead", "addr", addr, "size", size)
+}
+
+func (t *simpleTracer) OnCodeHashRead(addr gethcommon.Address, hash gethcommon.Hash) {
+	//log.Info("tenderly::OnCodeHashRead", "addr", addr, "hash", hash)
+}
+
+func (t *simpleTracer) OnStorageRead(addr gethcommon.Address, slot gethcommon.Hash, value gethcommon.Hash) {
+	//log.Info("tenderly::OnStorageRead", "addr", addr, "slot", slot, "value", value)
+}


### PR DESCRIPTION
# Live Tracing MVP
This PR introduces a minimalistic live tracing implementation that hooks into Geth for real-time block and transaction tracking. While this is a simplified version, our production tracer is significantly more robust, efficiently capturing blocks, transactions, and all relevant events.

The core idea is to track blockchain events in a highly performant way. The tracer constructs a block from OnBlockStart to OnBlockEnd, capturing key execution data. Once the block is fully traced, it is sent to our processing pipeline for further analysis.

This serves as a foundational example of how live tracing can be integrated, offering a lightweight yet functional approach to monitoring Ethereum execution flow.